### PR TITLE
Adding support for selecting openssl md, def to md5

### DIFF
--- a/crypttool
+++ b/crypttool
@@ -2,6 +2,7 @@
 
 __crypttool_editor=${EDITOR:-vim}
 __crypttool_verbose=0
+__crypttool_md=md5
 __crypttool_command=''
 __crypttool_varsfile=''
 __crypttool_password=''
@@ -22,6 +23,7 @@ _usage() {
   echo "args:"
   echo "  -p [password]   (en|de)cryption password"
   echo "  -k [passfile]   (en|de)cryption password file"
+  echo "  -m [md5|sha256] message digest format (default: md5)"
   echo "  -v              verbose"
   echo "  -h              help"
   echo
@@ -50,7 +52,7 @@ _decrypt() {
   local varsfile=${1:-$__crypttool_varsfile}
   _verbose "Decrypting file ${varsfile}"
   __crypttool_decrypted_file=$(mktemp -t crypttool.XXXXXX)
-  openssl aes-256-cbc -d -salt -in ${varsfile} -out ${__crypttool_decrypted_file} -k ${__crypttool_password}
+  openssl aes-256-cbc -d -salt -md ${__crypttool_md} -in ${varsfile} -out ${__crypttool_decrypted_file} -k ${__crypttool_password}
   [ $? -eq 0 ] || _error "Unable to decrypt password vars file ${varsfile}"
 }
 
@@ -58,7 +60,7 @@ _encrypt() {
   local varsfile=${1:-$__crypttool_varsfile}
   _verbose "Encrypting file ${varsfile}"
   __crypttool_encrypted_file=$(mktemp -t crypttool.XXXXXX)
-  echo "${__crypttool_password}" | openssl aes-256-cbc -salt -in ${varsfile} -out ${__crypttool_encrypted_file} -pass stdin
+  echo "${__crypttool_password}" | openssl aes-256-cbc -salt -md ${__crypttool_md} -in ${varsfile} -out ${__crypttool_encrypted_file} -pass stdin
   [ $? -eq 0 ] || _error "Unable to encrypt password vars file ${varsfile}"
 }
 
@@ -98,6 +100,7 @@ _main() {
     case "$1" in
       -p)        shift; __crypttool_password=${1};;
       -k)        shift; __crypttool_password_file=${1};;
+      -m)        shift; __crypttool_md=${1};;
       -v)        __crypttool_verbose=1;;
       -h|--help) _usage; exit;;
       *)         __crypttool_command=${1};

--- a/sempl
+++ b/sempl
@@ -7,6 +7,7 @@ __sempl_verbose=0
 __sempl_stdout=0
 __sempl_fail_missing=0
 __sempl_check=0
+__sempl_md=md5
 __sempl_template=''
 __sempl_outfile=''
 __sempl_varsfiles=( )
@@ -20,6 +21,7 @@ _usage() {
   echo "-s [varsfile]   vars file (can be repeated)"
   echo "-p [password]   decryption password"
   echo "-k [passfile]   decryption password file"
+  echo "-m [md5|sha256] message digest format (default: md5)"
   echo "-v              verbose"
   echo "-o              print template to stdout"
   echo "-f              fail if a variable is unset with no default"
@@ -114,6 +116,7 @@ _main() {
       -s)        shift; __sempl_varsfiles[${#__sempl_varsfiles[@]}]=${1};;
       -p)        shift; __sempl_password=${1};;
       -k)        shift; __sempl_password_file=${1};;
+      -m)        shift; __sempl_md=${1};;
       -v)        __sempl_verbose=1;;
       -o)        __sempl_stdout=1;;
       -f)        __sempl_fail_missing=1;;
@@ -144,7 +147,7 @@ _main() {
   for varsfile in "${__sempl_varsfiles[@]}"; do
     if head -1 ${varsfile} | grep -q -e '^Salted_'; then
       if [ ! -z "${__sempl_password}" ]; then
-        openssl aes-256-cbc -d -salt -in ${varsfile} -out ${varsfile}.unenc -k ${__sempl_password} \
+        openssl aes-256-cbc -d -salt -md ${__sempl_md} -in ${varsfile} -out ${varsfile}.unenc -k ${__sempl_password} \
           || { rm -f ${varsfile}.unenc; _error "Unable to decrypt password vars file ${varsfile}"; }
         source ${varsfile}.unenc \
           && rm -f ${varsfile}.unenc \


### PR DESCRIPTION
Default is md5 for versions of openssl < 1.1.0.

In 1.1.0, openssl changed default to sha256.  For any files encrypted with <1.1.0, it will need to be decrypted with `-md md5`, the new default for crypttool/sempl.  If users have newer openssl and encrypt files, they will need to be decrypted with `-md sha256`, which will require passing `-m sha256` to sempl or crypttool.

Since openssl 1.1.0 is not widely deployed (unless users are using new linux distros), it's most likely that the default md5 should work and no changes need to be made to scripts that use sempl/crypttool.