### PR TITLE
Added escaping special bash command characters to eval statement

### DIFF
--- a/sempl
+++ b/sempl
@@ -78,9 +78,15 @@ _convert_template() {
     set -o pipefail
   fi
   eval "echo \"$(cat ${__tmp_tmpl} \
-                   | sed 's/\"/\"\\\"/g' \
-                   | sed 's/</\\</g' \
-                   | sed 's/>/\\>/g')\"" \
+        | sed 's/\"/\"\\\"/g' \
+        | sed 's/</\\</g' \
+        | sed 's/>/\\>/g' \
+        | sed 's/;/\\;/g' \
+        | sed 's/&/\\&/g' \
+        | sed 's/-/\\-/g')\"" \
+    | sed 's/\\;/;/g' \
+    | sed 's/\\&/\&/g' \
+    | sed 's/\\-/-/g' \
     | sed 's/\\>/>/g' \
     | sed 's/\\</</g' \
     > $__sempl_outfile


### PR DESCRIPTION
* Previously files containing these special characters fail to output the template due to bash evaluating them as command characters, this should prevent that for those files that contain them